### PR TITLE
Implement Gin JSON-RPC dispatcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module godiatr
+
+go 1.23.8

--- a/library/dispatcher/dispatcher.go
+++ b/library/dispatcher/dispatcher.go
@@ -1,0 +1,59 @@
+package dispatcher
+
+import (
+	"github.com/gin-gonic/gin"
+	"godiatr/library/jsonrpc"
+)
+
+// Handler defines JSON-RPC handler
+// implementations should return a result object or a jsonrpc.Error
+// when something goes wrong.
+type Handler interface {
+	Method() string
+	Handle(*gin.Context, jsonrpc.Request) (interface{}, *jsonrpc.Error)
+}
+
+// Dispatcher routes JSON-RPC requests to registered handlers.
+type Dispatcher struct {
+	engine   *gin.Engine
+	handlers map[string]Handler
+}
+
+// New creates a dispatcher using the provided gin engine.
+func New(engine *gin.Engine) *Dispatcher {
+	return &Dispatcher{engine: engine, handlers: make(map[string]Handler)}
+}
+
+// Register adds a handler to dispatcher. Method name is taken from handler.Method().
+func (d *Dispatcher) Register(h Handler) { d.handlers[h.Method()] = h }
+
+// Bind attaches the dispatcher to given route path as POST handler.
+func (d *Dispatcher) Bind(path string) { d.engine.POST(path, d.dispatch) }
+
+// dispatch parses JSON-RPC request and executes registered handler.
+func (d *Dispatcher) dispatch(c *gin.Context) {
+	var req jsonrpc.Request
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(400, jsonrpc.NewErrorResponse(nil, jsonrpc.ErrInvalidRequest, "invalid request", nil))
+		return
+	}
+
+	if req.JSONRPC != jsonrpc.Version {
+		c.JSON(200, jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrInvalidRequest, "invalid jsonrpc version", nil))
+		return
+	}
+
+	h, ok := d.handlers[req.Method]
+	if !ok {
+		c.JSON(200, jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrMethodNotFound, "method not found", nil))
+		return
+	}
+
+	result, jerr := h.Handle(c, req)
+	if jerr != nil {
+		c.JSON(200, jsonrpc.NewErrorResponse(req.ID, jerr.Code, jerr.Message, jerr.Data))
+		return
+	}
+
+	c.JSON(200, jsonrpc.NewResultResponse(req.ID, result))
+}

--- a/library/dto/time.go
+++ b/library/dto/time.go
@@ -1,0 +1,5 @@
+package dto
+
+type Time struct {
+	Time string `json:"time"`
+}

--- a/library/handler/time.go
+++ b/library/handler/time.go
@@ -1,0 +1,17 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"godiatr/library/dto"
+	"godiatr/library/jsonrpc"
+	"time"
+)
+
+// TimeHandler returns server time in RFC3339 format.
+type TimeHandler struct{}
+
+func (h TimeHandler) Method() string { return "time.now" }
+
+func (h TimeHandler) Handle(c *gin.Context, req jsonrpc.Request) (interface{}, *jsonrpc.Error) {
+	return dto.Time{Time: time.Now().Format(time.RFC3339)}, nil
+}

--- a/library/jsonrpc/jsonrpc.go
+++ b/library/jsonrpc/jsonrpc.go
@@ -1,0 +1,49 @@
+package jsonrpc
+
+import "encoding/json"
+
+const Version = "2.0"
+
+const (
+	ErrParseError     = -32700
+	ErrInvalidRequest = -32600
+	ErrMethodNotFound = -32601
+	ErrInvalidParams  = -32602
+	ErrInternal       = -32603
+)
+
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type Response struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *Error      `json:"error,omitempty"`
+}
+
+type Error struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+func NewResultResponse(id interface{}, result interface{}) Response {
+	return Response{
+		JSONRPC: Version,
+		ID:      id,
+		Result:  result,
+	}
+}
+
+func NewErrorResponse(id interface{}, code int, msg string, data interface{}) Response {
+	return Response{
+		JSONRPC: Version,
+		ID:      id,
+		Error:   &Error{Code: code, Message: msg, Data: data},
+	}
+}

--- a/library/request/time_request.go
+++ b/library/request/time_request.go
@@ -1,0 +1,3 @@
+package request
+
+type TimeRequest struct{}

--- a/library/response/time_response.go
+++ b/library/response/time_response.go
@@ -1,0 +1,7 @@
+package response
+
+import "godiatr/library/dto"
+
+type TimeResponse struct {
+	dto.Time
+}


### PR DESCRIPTION
## Summary
- add Go module
- create JSON-RPC helper definitions
- build dispatcher pattern with Gin
- implement example time handler
- organize code under library/handler, request, response, dto

## Testing
- `go mod tidy` *(fails: Get "https://proxy.golang.org/github.com/gin-gonic/gin/@v/list": Forbidden)*
- `go test ./...` *(fails: no required module provides package github.com/gin-gonic/gin)*

------
https://chatgpt.com/codex/tasks/task_e_6847153a4fa0832eafee939a1a4742b6